### PR TITLE
refactor: remove redundant 'model' field from metadata

### DIFF
--- a/stories/story_generator.py
+++ b/stories/story_generator.py
@@ -120,7 +120,6 @@ class StoryGenerationApp:
             metadata = {}
             if response.metadata:
                 metadata = {
-                    "model": response.metadata.get("model", ""),
                     "role": response.metadata.get("role", ""),
                     "stop_reason": response.metadata.get("stop_reason", ""),
                     "stop_sequence": response.metadata.get("stop_sequence", "")


### PR DESCRIPTION
Remove the unused "model" field from the metadata dictionary in the 
StoryGenerationApp class. This is already part of the LLM information in the object.